### PR TITLE
Subdag inherit runid *Do not merge*

### DIFF
--- a/airflow/jobs.py
+++ b/airflow/jobs.py
@@ -1922,6 +1922,7 @@ class BackfillJob(BaseJob):
             ignore_task_deps=False,
             pool=None,
             delay_on_limit_secs=1.0,
+            run_id_template=None,
             *args, **kwargs):
         self.dag = dag
         self.dag_id = dag.dag_id
@@ -1934,6 +1935,9 @@ class BackfillJob(BaseJob):
         self.ignore_task_deps = ignore_task_deps
         self.pool = pool
         self.delay_on_limit_secs = delay_on_limit_secs
+        self.run_id_template = BackfillJob.ID_FORMAT_PREFIX
+        if run_id_template:
+            self.run_id_template = run_id_template
         super(BackfillJob, self).__init__(*args, **kwargs)
 
     def _update_counters(self, ti_status):
@@ -2023,7 +2027,7 @@ class BackfillJob(BaseJob):
         :type session: Session
         :return: a DagRun in state RUNNING or None
         """
-        run_id = BackfillJob.ID_FORMAT_PREFIX.format(run_date.isoformat())
+        run_id = self.run_id_template.format(run_date.isoformat())
 
         # consider max_active_runs but ignore when running subdags
         respect_dag_max_active_limit = (True

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -3675,7 +3675,9 @@ class DAG(BaseDag, LoggingMixin):
             ignore_task_deps=False,
             ignore_first_depends_on_past=False,
             pool=None,
-            delay_on_limit_secs=1.0):
+            delay_on_limit_secs=1.0,
+            run_id_template=None
+    ):
         """
         Runs the DAG.
 
@@ -3703,6 +3705,8 @@ class DAG(BaseDag, LoggingMixin):
         :param delay_on_limit_secs: Time in seconds to wait before next attempt to run
             dag run when max_active_runs limit has been reached
         :type delay_on_limit_secs: float
+        :param run_id_template: Template for the run_id to be with the execution date
+        :type run_id_template: string
         """
         from airflow.jobs import BackfillJob
         if not executor and local:
@@ -3720,7 +3724,9 @@ class DAG(BaseDag, LoggingMixin):
             ignore_task_deps=ignore_task_deps,
             ignore_first_depends_on_past=ignore_first_depends_on_past,
             pool=pool,
-            delay_on_limit_secs=delay_on_limit_secs)
+            delay_on_limit_secs=delay_on_limit_secs,
+            run_id_template=run_id_template
+        )
         job.run()
 
     def cli(self):

--- a/airflow/operators/subdag_operator.py
+++ b/airflow/operators/subdag_operator.py
@@ -87,6 +87,11 @@ class SubDagOperator(BaseOperator):
 
     def execute(self, context):
         ed = context['execution_date']
+        # Use the parent's run id as a template for the subdag dag run's run_id
+        run_id = context['run_id']
+        run_id_template = run_id + '{0}'
         self.subdag.run(
             start_date=ed, end_date=ed, donot_pickle=True,
-            executor=self.executor)
+            executor=self.executor,
+            run_id_template=run_id_template
+        )

--- a/airflow/operators/subdag_operator.py
+++ b/airflow/operators/subdag_operator.py
@@ -89,7 +89,7 @@ class SubDagOperator(BaseOperator):
         ed = context['execution_date']
         # Use the parent's run id as a template for the subdag dag run's run_id
         run_id = context['run_id']
-        run_id_template = run_id + '{0}'
+        run_id_template = run_id + '.{0}'
         self.subdag.run(
             start_date=ed, end_date=ed, donot_pickle=True,
             executor=self.executor,


### PR DESCRIPTION
Recreated PR from 2018 that was into apache / airflow.

===
Original [comment](https://github.com/apache/airflow/pull/3761#issue-351385085) from Aug. 16, 2018:

> I wanted the subdag run id to be prefixed with the name of the dag it was called from. This makes the run names more informative, when looking at the graph view of the subdag, instead of the generic time stamp.
>
> My solution here may break others use cases, so not meant to be a generic solution. However, perhaps one can bake in some functionality allow for the subdag run ids to be user defined.

===
Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [ ] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
